### PR TITLE
Protocol june update

### DIFF
--- a/protocol/01.md
+++ b/protocol/01.md
@@ -1,12 +1,12 @@
 # TIP-01 - Base Events
-`draft` `mandatory` `kind=21021` `kind=21000`
+`draft` `mandatory` `kind=10021` `kind=21000` `kind=1022`
 
 ---
 ## TollGate Discovery
 Tollgate Details / Advertisement is expressed through the following Nostr event
 ```json
 {
-    "kind": 21021,
+    "kind": 10021,
     "pubkey": "24d6...3662", // TollGate identity
     // ...
     "tags": [
@@ -25,8 +25,8 @@ Tags:
 ### Example
 ```json
 {
-    "kind": 21021,
-    "pubkey": "24d6...3662", // TollGate identity
+    "kind": 10021,
+    "pubkey": "24d6...3662",
     // ...
     "tags": [
         ["metric", "milliseconds"],
@@ -59,7 +59,7 @@ Tags:
 ## Session
 ```json
 {
-	"kind": 21022,
+	"kind": 1022,
 	"pubkey": "63gy...9xvq", // TollGate identity
 	// ...
 	"tags": [

--- a/protocol/01.md
+++ b/protocol/01.md
@@ -66,7 +66,8 @@ Tags:
 	"tags": [
 		["p", "6hjq...1fi6"], // Customer identity (pubkey)
 		["device-identifier", "<type>", "<value>"],
-		["purchased_steps", "<amount>"]
+		["allotment", "<amount>"]
+		["metric", "<metric>"]
 	]
 }
 ```
@@ -74,7 +75,8 @@ Tags:
 Tags:
 - `p`: pubkey of the TollCustomer Gate (from the Customer's Payment event)
 - `device-identifier`: (hardware) identifier of the customer's device.
-- `purchased_steps`: Amount of steps allotted to customer after payment. Should be used by customer for internal measuring/acccounting.
+- `allotment`: Amount of `<metric>` allotted to customer after payment.
+- `metric`: The purchased metric
 
 ## Notice Events
 

--- a/protocol/01.md
+++ b/protocol/01.md
@@ -122,7 +122,7 @@ Human-readable message describing the issue or information. Should be user-frien
     "kind": 21023,
     "pubkey": "24d6...3662",
     "tags": [
-        ["level", "warning"],
+        ["level", "error"],
         ["code", "upstream-error-not-connected"]
     ],
     "content": "TollGate Currently has no upstream connection.",

--- a/protocol/01.md
+++ b/protocol/01.md
@@ -74,3 +74,58 @@ Tags:
 - `p`: pubkey of the TollCustomer Gate (from the Customer's Payment event)
 - `device-identifier`: (hardware) identifier of the customer's device.
 - `purchased_steps`: Amount of steps allotted to customer after payment. Should be used by customer for internal measuring/acccounting.
+
+## Notice Events
+
+Notice events are used by TollGates to communicate issues, warnings, and informational messages to customers. These events provide structured error reporting and debugging information.
+
+```json
+{
+    "kind": 21023,
+    "pubkey": "<tollgate_pubkey>",
+    "tags": [
+        ["p", "customer_pubkey"], // Optional - only when addressing specific customer
+        ["level", "<error|warning|info|debug>"],
+        ["code", "<text-code>"]
+    ],
+    "content": "Human-readable message",
+    // ...
+}
+```
+
+### Tags
+
+#### Required Tags
+- `level`: Severity level of the notice
+  - `error`: Critical errors preventing operation
+  - `warning`: Non-critical issues that may affect experience
+  - `info`: Informational messages
+  - `debug`: Debug information for troubleshooting, should not be used in production settings.
+
+- `code`: Machine-readable error code for programmatic handling. Examples:
+  - `session-error`: Session creation or management error
+  - `payment-error-mint-not-accepted`: Payment from unsupported mint
+  - `payment-error-token-spent`: Cashu token already spent
+
+#### Optional Tags
+- `p`: Customer pubkey when addressing a specific customer. Omitted for general notices.
+
+### Content
+Human-readable message describing the issue or information. Should be user-friendly and provide actionable guidance when possible.
+
+### Examples
+
+#### Payment Error
+```json
+{
+    "kind": 21023,
+    "pubkey": "24d6...3662",
+    "tags": [
+        ["p", "63gy...9xvq"],
+        ["level", "error"],
+        ["code", "payment-error-token-spent"]
+    ],
+    "content": "Payment processing failed: Token already spent",
+    // ...
+}
+```

--- a/protocol/01.md
+++ b/protocol/01.md
@@ -47,3 +47,24 @@ Tags:
 - `p`: pubkey of the TollGate (from the TollGate Details event) who takes the payment
 - `device-identifier`: (hardware) identifier of the customer's device. Second argument specifies kind of identifier, third argument is the identifier value.
 - `payment`: Cashu token
+
+
+## Session
+```json
+{
+	kind: 21022,
+	pubkey: "63gy...9xvq", // Can be randomly generated
+	content: "", 
+	created_at: UNIX_TIMESTAMP,
+	tags: [
+		["p", "6hjq...1fi6"], // Customer identity (pubkey)
+		["device-identifier", "mac", "00:1A:2B:3C:4D:5E"],
+		["purchased_steps", "60"]
+	]
+}
+```
+
+Tags:
+- `p`: pubkey of the TollCustomer Gate (from the Customer's Payment event)
+- `device-identifier`: (hardware) identifier of the customer's device. Second argument specifies kind of identifier, third argument is the identifier value.
+- `purchased_steps`: Amount of steps allotted to customer after payment. Should be used by customer for internal measuring/acccounting.

--- a/protocol/01.md
+++ b/protocol/01.md
@@ -19,7 +19,7 @@ Tollgate Details / Advertisement is expressed through the following Nostr event
 
 Tags:
 - `metric`: `milliseconds` or `bytes`
-- `step_size`: positive whole number.
+- `min_steps`: (Optional) positive whole number. Defines a minimum amount of steps a customer must purchase at a time.
 - `tips`: List of implemented TollGate TIP's represented as numbers
 
 ### Example
@@ -31,6 +31,7 @@ Tags:
     "tags": [
         ["metric", "milliseconds"],
         ["step_size", "60000"], // 1 minute step size
+        ["step_purchase_limits", "1", "0"], // Min 1 minute, max infinite minutes
         ["tips", "1", "2", "5", "..."]
     ]
 }

--- a/protocol/01.md
+++ b/protocol/01.md
@@ -46,17 +46,17 @@ Tags:
 ```json
 {
 	"kind": 21022,
-	"pubkey": "63gy...9xvq", // Customer Identity, Can be randomly generated
+	"pubkey": "63gy...9xvq", // TollGate identity
 	// ...
 	"tags": [
 		["p", "6hjq...1fi6"], // Customer identity (pubkey)
 		["device-identifier", "<type>", "<value>"],
-		["purchased_steps", "60"]
+		["purchased_steps", "<amount>"]
 	]
 }
 ```
 
 Tags:
 - `p`: pubkey of the TollCustomer Gate (from the Customer's Payment event)
-- `device-identifier`: (hardware) identifier of the customer's device. Second argument specifies kind of identifier, third argument is the identifier value.
+- `device-identifier`: (hardware) identifier of the customer's device.
 - `purchased_steps`: Amount of steps allotted to customer after payment. Should be used by customer for internal measuring/acccounting.

--- a/protocol/01.md
+++ b/protocol/01.md
@@ -104,6 +104,7 @@ Notice events are used by TollGates to communicate issues, warnings, and informa
 
 - `code`: Machine-readable error code for programmatic handling. Examples:
   - `session-error`: Session creation or management error
+  - `upstream-error-not-connected`: TollGate has no upstream connection
   - `payment-error-mint-not-accepted`: Payment from unsupported mint
   - `payment-error-token-spent`: Cashu token already spent
 
@@ -114,6 +115,20 @@ Notice events are used by TollGates to communicate issues, warnings, and informa
 Human-readable message describing the issue or information. Should be user-friendly and provide actionable guidance when possible.
 
 ### Examples
+
+#### No Upstream Error
+```json
+{
+    "kind": 21023,
+    "pubkey": "24d6...3662",
+    "tags": [
+        ["level", "warning"],
+        ["code", "upstream-error-not-connected"]
+    ],
+    "content": "TollGate Currently has no upstream connection.",
+    // ...
+}
+```
 
 #### Payment Error
 ```json

--- a/protocol/01.md
+++ b/protocol/01.md
@@ -2,20 +2,16 @@
 `draft` `mandatory` `kind=21021` `kind=21000`
 
 ---
-## TollGate Details
-Tollgate details are expressed through the following Nostr event
+## TollGate Discovery
+Tollgate Details / Advertisement is expressed through the following Nostr event
 ```json
 {
-    kind: 21021,
-    pubkey: "24d6...3662", // TollGate identity
-    content: "", 
-    created_at: UNIX_TIMESTAMP,
-    tags: [
+    "kind": 21021,
+    "pubkey": "24d6...3662", // TollGate identity
+    // ...
+    "tags": [
         ["metric", "milliseconds"],
         ["step_size", "60000"],
-        ["price_per_step", "210", "sat"],
-        ["mint", "https://mint.domain.net"],
-        ["mint", "https://mint.anotherdomain.net"],
         ["tips", "1", "2", "5", "..."]
     ]
 }
@@ -24,41 +20,37 @@ Tollgate details are expressed through the following Nostr event
 Tags:
 - `metric`: `milliseconds` or `bytes`
 - `step_size`: positive whole number. Example: 1 minute step size
-- `price_per_step`: price for purchasing 1 time the `step_size`, third argument is the price unit. Example: 210 sats per minute (60000ms)
-- `mint`: (one or more) Accepted Cashu mints
 - `tips`: List of implemented TollGate TIP's represented as numbers
 
 ## Payment
 ```json
 {
-	kind: 21000,
-	pubkey: "63gy...9xvq", // Can be randomly generated
-	content: "", 
-	created_at: UNIX_TIMESTAMP,
-	tags: [
+	"kind": 21000,
+	"pubkey": "63gy...9xvq", // Customer Identity, Can be randomly generated
+	// ...
+	"tags": [
 		["p", "24d6...3662"], // TollGate identity (pubkey)
-		["device-identifier", "mac", "00:1A:2B:3C:4D:5E"],
-		["payment", "cashuB..."]
+		["device-identifier", "<type>", "<value>"],
+		["payment", "<bearer_asset>"]
 	]
 }
 ```
 
 Tags:
 - `p`: pubkey of the TollGate (from the TollGate Details event) who takes the payment
-- `device-identifier`: (hardware) identifier of the customer's device. Second argument specifies kind of identifier, third argument is the identifier value.
-- `payment`: Cashu token
+- `device-identifier`: (hardware) identifier of the customer's device. Second argument specifies type of identifier, third argument is the identifier value. `["device-identifier", "mac", "00:1A:2B:3C:4D:5E"]`
+- `payment`: Bearer asset, such as Cashu token `["payment", "cashuB..."]`
 
 
 ## Session
 ```json
 {
-	kind: 21022,
-	pubkey: "63gy...9xvq", // Can be randomly generated
-	content: "", 
-	created_at: UNIX_TIMESTAMP,
-	tags: [
+	"kind": 21022,
+	"pubkey": "63gy...9xvq", // Customer Identity, Can be randomly generated
+	// ...
+	"tags": [
 		["p", "6hjq...1fi6"], // Customer identity (pubkey)
-		["device-identifier", "mac", "00:1A:2B:3C:4D:5E"],
+		["device-identifier", "<type>", "<value>"],
 		["purchased_steps", "60"]
 	]
 }

--- a/protocol/01.md
+++ b/protocol/01.md
@@ -10,8 +10,8 @@ Tollgate Details / Advertisement is expressed through the following Nostr event
     "pubkey": "24d6...3662", // TollGate identity
     // ...
     "tags": [
-        ["metric", "milliseconds"],
-        ["step_size", "60000"],
+        ["metric", "<value>"],
+        ["step_size", "<value>"],
         ["tips", "1", "2", "5", "..."]
     ]
 }
@@ -19,8 +19,22 @@ Tollgate Details / Advertisement is expressed through the following Nostr event
 
 Tags:
 - `metric`: `milliseconds` or `bytes`
-- `step_size`: positive whole number. Example: 1 minute step size
+- `step_size`: positive whole number.
 - `tips`: List of implemented TollGate TIP's represented as numbers
+
+### Example
+```json
+{
+    "kind": 21021,
+    "pubkey": "24d6...3662", // TollGate identity
+    // ...
+    "tags": [
+        ["metric", "milliseconds"],
+        ["step_size", "60000"], // 1 minute step size
+        ["tips", "1", "2", "5", "..."]
+    ]
+}
+```
 
 ## Payment
 ```json

--- a/protocol/02.md
+++ b/protocol/02.md
@@ -1,15 +1,59 @@
-# TIP-02 - TCP/IP
-`draft` `optional`
+# TIP-02 - Cashu payments
+`draft` `mandatory` `kind=21021` `kind=21000`
 
 ---
 
-Minimal setup for allowing payments on LAN networks.
+- A TollGate can accept multiple mints and multiple currencies.
 
-## POST /
-The Server must take a http `POST` request containing a valid [Payment](#payment) event in the request body.
-If the operator deems the provided cashu token valid it must return a `200 OK` status and provide the customer's provided device identifier internet access for the metric it sells relative to the amount provided by the customer. If the payment is invalid, a http `402 Payment Required` status MAY be returned.
+## TollGate Discovery
 
-## GET /
-A `GET` request on the root endpoint may return http status `200 OK` where the response body contains the [TollGate Details](#tollgate-details) event.
+A TollGate that accepts Cashu tokens as payment may advertise its pricing using the following tags.
 
-TODO: move advertisement endpoint out of this TIP
+```json
+{
+    "kind": 21021,
+    // ...
+    "tags": [
+        // <TIP-01 tags>
+        ["price_per_step", "<price>", "<unit>", "<mint_url>"],
+        ["price_per_step", "...", "...", "..."],
+    ]
+}
+```
+
+Tags:
+- `price_per_step`: (one or more)
+	- `<price>` price for purchasing 1 time the `step_size`.
+	- `<unit>` unit or currency.
+	- `<mint_url>` Accepted mint. Example: 210 sats per minute (60000ms)
+
+- The value of `<price>` MUST be the same across all occurrences of the same `<unit>` value.
+
+### Example
+```json
+{
+    "kind": 21021,
+    // ...
+    "tags": [
+        // <TIP-01 tags>
+        ["price_per_step", "210", "sat", "https://mint.domain.net"],
+        ["price_per_step", "210", "sat", "https://other.mint.net"],
+        ["price_per_step", "500", "eur", "https://mint.thirddomain.eu"],
+    ]
+}
+```
+
+## Payment
+```json
+{
+	"kind": 21000,
+	// ...
+	"tags": [
+		// <TIP-01 tags>
+		["payment", "cashuB..."]
+	]
+}
+```
+
+Tags:
+- `payment`: Cashu Token

--- a/protocol/02.md
+++ b/protocol/02.md
@@ -1,5 +1,5 @@
 # TIP-02 - Cashu payments
-`draft` `mandatory` `kind=21021` `kind=21000`
+`draft` `mandatory` `kind=10021` `kind=21000` `kind=1022`
 
 ---
 
@@ -11,7 +11,7 @@ A TollGate that accepts Cashu tokens as payment may advertise its pricing using 
 
 ```json
 {
-    "kind": 21021,
+    "kind": 10021,
     // ...
     "tags": [
         // <TIP-01 tags>
@@ -33,7 +33,7 @@ Tags:
 ### Example
 ```json
 {
-    "kind": 21021,
+    "kind": 10021,
     // ...
     "tags": [
         // <TIP-01 tags>

--- a/protocol/02.md
+++ b/protocol/02.md
@@ -15,8 +15,8 @@ A TollGate that accepts Cashu tokens as payment may advertise its pricing using 
     // ...
     "tags": [
         // <TIP-01 tags>
-        ["price_per_step", "<bearer_asset_type>", "<price>", "<unit>", "<mint_url>", "<mint_fee>"],
-        ["price_per_step", "...", "...", "..."],
+        ["price_per_step", "<bearer_asset_type>", "<price>", "<unit>", "<mint_url>", "<min_steps>"],
+        ["price_per_step", "...", "...", "...", "...", "..."],
     ]
 }
 ```
@@ -27,7 +27,7 @@ Tags:
 	- `<price>` price for purchasing 1 time the `step_size`.
 	- `<unit>` unit or currency.
 	- `<mint_url>` Accepted mint. Example: 210 sats per minute (60000ms)
-	- `<mint_fee>` Mint fee, required for customer
+	- `<min_steps>` Minimum amount of steps to purchase using this mint. Positive whole number, default 0 ⚠️ TENTATIVE: Strucuture of incorporation of fees/min purchases is not final
 
 - The value of `<price>` MUST be the same across all occurrences of the same `<unit>` value.
 
@@ -38,9 +38,9 @@ Tags:
     // ...
     "tags": [
         // <TIP-01 tags>
-        ["price_per_step", "cashu", "210", "sat", "https://mint.domain.net", "0"],
-        ["price_per_step", "cashu", "210", "sat", "https://other.mint.net", "1"],
-        ["price_per_step", "cashu", "500", "eur", "https://mint.thirddomain.eu", "25"],
+        ["price_per_step", "cashu", "210", "sat", "https://mint.domain.net", 1],
+        ["price_per_step", "cashu", "210", "sat", "https://other.mint.net", 1],
+        ["price_per_step", "cashu", "500", "eur", "https://mint.thirddomain.eu", 3],
     ]
 }
 ```

--- a/protocol/02.md
+++ b/protocol/02.md
@@ -15,7 +15,7 @@ A TollGate that accepts Cashu tokens as payment may advertise its pricing using 
     // ...
     "tags": [
         // <TIP-01 tags>
-        ["price_per_step", "<price>", "<unit>", "<mint_url>", "<mint_fee>"],
+        ["price_per_step", "<bearer_asset_type>", "<price>", "<unit>", "<mint_url>", "<mint_fee>"],
         ["price_per_step", "...", "...", "..."],
     ]
 }
@@ -23,6 +23,7 @@ A TollGate that accepts Cashu tokens as payment may advertise its pricing using 
 
 Tags:
 - `price_per_step`: (one or more)
+	- `<bearer_asset_type>` Always `cashu`.
 	- `<price>` price for purchasing 1 time the `step_size`.
 	- `<unit>` unit or currency.
 	- `<mint_url>` Accepted mint. Example: 210 sats per minute (60000ms)
@@ -37,9 +38,9 @@ Tags:
     // ...
     "tags": [
         // <TIP-01 tags>
-        ["price_per_step", "210", "sat", "https://mint.domain.net", "0"],
-        ["price_per_step", "210", "sat", "https://other.mint.net", "1"],
-        ["price_per_step", "500", "eur", "https://mint.thirddomain.eu", "25"],
+        ["price_per_step", "cashu", "210", "sat", "https://mint.domain.net", "0"],
+        ["price_per_step", "cashu", "210", "sat", "https://other.mint.net", "1"],
+        ["price_per_step", "cashu", "500", "eur", "https://mint.thirddomain.eu", "25"],
     ]
 }
 ```

--- a/protocol/02.md
+++ b/protocol/02.md
@@ -15,7 +15,7 @@ A TollGate that accepts Cashu tokens as payment may advertise its pricing using 
     // ...
     "tags": [
         // <TIP-01 tags>
-        ["price_per_step", "<price>", "<unit>", "<mint_url>"],
+        ["price_per_step", "<price>", "<unit>", "<mint_url>", "<mint_fee>"],
         ["price_per_step", "...", "...", "..."],
     ]
 }
@@ -26,6 +26,7 @@ Tags:
 	- `<price>` price for purchasing 1 time the `step_size`.
 	- `<unit>` unit or currency.
 	- `<mint_url>` Accepted mint. Example: 210 sats per minute (60000ms)
+	- `<mint_fee>` Mint fee, required for customer
 
 - The value of `<price>` MUST be the same across all occurrences of the same `<unit>` value.
 
@@ -36,14 +37,17 @@ Tags:
     // ...
     "tags": [
         // <TIP-01 tags>
-        ["price_per_step", "210", "sat", "https://mint.domain.net"],
-        ["price_per_step", "210", "sat", "https://other.mint.net"],
+        ["price_per_step", "210", "sat", "https://mint.domain.net", 1],
+        ["price_per_step", "210", "sat", "https://other.mint.net", 1],
         ["price_per_step", "500", "eur", "https://mint.thirddomain.eu"],
     ]
 }
 ```
 
 ## Payment
+
+When the customer pays an exact multiple of `<price_per_step>` and adds `<mint_fee>`. The TolGate MUST allot at least that amount of steps to the customer.
+
 ```json
 {
 	"kind": 21000,

--- a/protocol/02.md
+++ b/protocol/02.md
@@ -37,9 +37,9 @@ Tags:
     // ...
     "tags": [
         // <TIP-01 tags>
-        ["price_per_step", "210", "sat", "https://mint.domain.net", 1],
-        ["price_per_step", "210", "sat", "https://other.mint.net", 1],
-        ["price_per_step", "500", "eur", "https://mint.thirddomain.eu"],
+        ["price_per_step", "210", "sat", "https://mint.domain.net", "0"],
+        ["price_per_step", "210", "sat", "https://other.mint.net", "1"],
+        ["price_per_step", "500", "eur", "https://mint.thirddomain.eu", "25"],
     ]
 }
 ```

--- a/protocol/03.md
+++ b/protocol/03.md
@@ -12,7 +12,58 @@ If the TollGate accepts the provided payment it MUST return http `200 OK` respon
 
 If the payment is invalid, it MAY return a http `402 Payment Required` status.
 
+### CURL Request Example (Successful Payment):
+
+```bash
+curl -X POST http://192.168.1.1/ # TollGate IP
+  -H "Content-Type: application/json" \
+  -d '{
+    "kind": 21000,
+    ...
+  }'
+```
+
+### Response Example (Successful Payment):
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 456
+
+{
+  "kind": 21022,
+  ...
+}
+```
+
+### Response Example (Invalid Payment):
+
+```
+HTTP/1.1 402 Payment Required
+Content-Type: text/plain
+Content-Length: 15
+
+This mint is not accepted
+```
+
 ## GET /
 A `GET` request on the root endpoint MAY return http `200 OK` response where the  body is a `kind=21021` TollGate Discovery event.
 
-TODO: move advertisement endpoint out of this TIP
+### CURL Request Example:
+
+```bash
+curl -X GET http://192.168.1.1/ # TollGate IP
+```
+
+### Response Example:
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 398
+
+{
+  "kind": 21021,
+  ...
+}
+```

--- a/protocol/03.md
+++ b/protocol/03.md
@@ -1,4 +1,4 @@
-# TIP-02 - TCP/IP
+# TIP-03 - TCP/IP
 `draft` `optional`
 
 ---

--- a/protocol/03.md
+++ b/protocol/03.md
@@ -1,14 +1,15 @@
-# TIP-03 - Restrictive OS compatibility
+# TIP-02 - TCP/IP
 `draft` `optional`
 
 ---
-Builds on TIP-02
 
-## GET /whoami
-A `GET` request on the `/whoami` endpoint must return http status `200 OK` with the body containing the customer's `device-identifier` that the customer must include in their payment. Formatted as `[type]=[value]`
+Minimal setup for allowing payments on LAN networks.
 
-### Example:
+## POST /
+The Server must take a http `POST` request containing a valid [Payment](#payment) event in the request body.
+If the operator deems the provided cashu token valid it must return a `200 OK` status and provide the customer's provided device identifier internet access for the metric it sells relative to the amount provided by the customer. If the payment is invalid, a http `402 Payment Required` status MAY be returned.
 
-```
-mac=00:1A:2B:3C:4D:5E
-```
+## GET /
+A `GET` request on the root endpoint may return http status `200 OK` where the response body contains the [TollGate Details](#tollgate-details) event.
+
+TODO: move advertisement endpoint out of this TIP

--- a/protocol/03.md
+++ b/protocol/03.md
@@ -3,7 +3,7 @@
 
 ---
 
-Minimal setup for allowing payments on LAN networks.
+Minimal setup for allowing payments on LAN networks. Default port `2121`
 
 ## POST /
 The Server MUST take a http `POST` request containing a valid [Payment](#payment) event in the request body.
@@ -15,7 +15,7 @@ If the payment is invalid, it MAY return a http `402 Payment Required` status.
 ### CURL Request Example (Successful Payment):
 
 ```bash
-curl -X POST http://192.168.1.1/ # TollGate IP
+curl -X POST http://192.168.1.1:2121/ # TollGate IP
   -H "Content-Type: application/json" \
   -d '{
     "kind": 21000,
@@ -52,7 +52,7 @@ A `GET` request on the root endpoint MAY return http `200 OK` response where the
 ### CURL Request Example:
 
 ```bash
-curl -X GET http://192.168.1.1/ # TollGate IP
+curl -X GET http://192.168.1.1:2121/ # TollGate IP
 ```
 
 ### Response Example:

--- a/protocol/03.md
+++ b/protocol/03.md
@@ -1,5 +1,5 @@
 # TIP-03 - Http server
-`draft` `optional`
+`draft` `optional` `kind=21000` `kind=1022` `kind=10021`
 
 ---
 
@@ -8,7 +8,7 @@ Minimal setup for allowing payments on LAN networks. Default port `2121`
 ## POST /
 The Server MUST take a http `POST` request containing a valid [Payment](#payment) event in the request body.
 
-If the TollGate accepts the provided payment it MUST return http `200 OK` response where the body is a `kind=21022` TollGate Session event.
+If the TollGate accepts the provided payment it MUST return http `200 OK` response where the body is a `kind=1022` TollGate Session event.
 
 If the payment is invalid, it MAY return a http `402 Payment Required` status.
 
@@ -31,7 +31,7 @@ Content-Type: application/json
 Content-Length: 456
 
 {
-  "kind": 21022,
+  "kind": 1022,
   ...
 }
 ```
@@ -47,7 +47,7 @@ This mint is not accepted
 ```
 
 ## GET /
-A `GET` request on the root endpoint MAY return http `200 OK` response where the  body is a `kind=21021` TollGate Discovery event.
+A `GET` request on the root endpoint MAY return http `200 OK` response where the  body is a `kind=10021` TollGate Discovery event.
 
 ### CURL Request Example:
 
@@ -63,7 +63,7 @@ Content-Type: application/json
 Content-Length: 398
 
 {
-  "kind": 21021,
+  "kind": 10021,
   ...
 }
 ```

--- a/protocol/03.md
+++ b/protocol/03.md
@@ -1,4 +1,4 @@
-# TIP-03 - TCP/IP
+# TIP-03 - Http server
 `draft` `optional`
 
 ---

--- a/protocol/03.md
+++ b/protocol/03.md
@@ -6,10 +6,13 @@
 Minimal setup for allowing payments on LAN networks.
 
 ## POST /
-The Server must take a http `POST` request containing a valid [Payment](#payment) event in the request body.
-If the operator deems the provided cashu token valid it must return a `200 OK` status and provide the customer's provided device identifier internet access for the metric it sells relative to the amount provided by the customer. If the payment is invalid, a http `402 Payment Required` status MAY be returned.
+The Server MUST take a http `POST` request containing a valid [Payment](#payment) event in the request body.
+
+If the TollGate accepts the provided payment it MUST return http `200 OK` response where the body is a `kind=21022` TollGate Session event.
+
+If the payment is invalid, it MAY return a http `402 Payment Required` status.
 
 ## GET /
-A `GET` request on the root endpoint may return http status `200 OK` where the response body contains the [TollGate Details](#tollgate-details) event.
+A `GET` request on the root endpoint MAY return http `200 OK` response where the  body is a `kind=21021` TollGate Discovery event.
 
 TODO: move advertisement endpoint out of this TIP

--- a/protocol/04.md
+++ b/protocol/04.md
@@ -8,8 +8,18 @@ A `GET` request on the `/whoami` endpoint MUST return http status `200 OK` with 
 
 Formatted as `[type]=[value]`
 
-### Example:
+### CURL Request Example:
+
+```bash
+curl -X GET http://192.168.8.1/whoami # TollGate IP
+```
+
+### Response Example:
 
 ```
+HTTP/1.1 200 OK
+Content-Type: text/plain
+Content-Length: 20
+
 mac=00:1A:2B:3C:4D:5E
 ```

--- a/protocol/04.md
+++ b/protocol/04.md
@@ -1,5 +1,5 @@
 # TIP-04 - Restrictive OS compatibility
-`draft` `optional`
+`draft` `optional` `kind=21000`
 
 ---
 

--- a/protocol/04.md
+++ b/protocol/04.md
@@ -6,12 +6,14 @@
 ## GET /whoami
 A `GET` request on the `/whoami` endpoint MUST return http status `200 OK` with the body containing the customer's `<device-identifier>` that the customer MUST include in their payment event.
 
+http port MUST be the same as [TIP-03](./03.md)
+
 Formatted as `[type]=[value]`
 
 ### CURL Request Example:
 
 ```bash
-curl -X GET http://192.168.8.1/whoami # TollGate IP
+curl -X GET http://192.168.1.1:2121/whoami # TollGate IP
 ```
 
 ### Response Example:

--- a/protocol/04.md
+++ b/protocol/04.md
@@ -2,10 +2,11 @@
 `draft` `optional`
 
 ---
-Builds on TIP-02
 
 ## GET /whoami
-A `GET` request on the `/whoami` endpoint must return http status `200 OK` with the body containing the customer's `device-identifier` that the customer must include in their payment. Formatted as `[type]=[value]`
+A `GET` request on the `/whoami` endpoint MUST return http status `200 OK` with the body containing the customer's `<device-identifier>` that the customer MUST include in their payment event.
+
+Formatted as `[type]=[value]`
 
 ### Example:
 

--- a/protocol/04.md
+++ b/protocol/04.md
@@ -1,4 +1,4 @@
-# TIP-03 - Restrictive OS compatibility
+# TIP-04 - Restrictive OS compatibility
 `draft` `optional`
 
 ---

--- a/protocol/04.md
+++ b/protocol/04.md
@@ -1,6 +1,14 @@
-# TIP-04 - Beacon Frame Advertisement
+# TIP-03 - Restrictive OS compatibility
 `draft` `optional`
 
 ---
-- TODO: put stuff in beaconframe
+Builds on TIP-02
 
+## GET /whoami
+A `GET` request on the `/whoami` endpoint must return http status `200 OK` with the body containing the customer's `device-identifier` that the customer must include in their payment. Formatted as `[type]=[value]`
+
+### Example:
+
+```
+mac=00:1A:2B:3C:4D:5E
+```

--- a/protocol/05.md
+++ b/protocol/05.md
@@ -1,4 +1,4 @@
-# TIP-04 - Beacon Frame Advertisement
+# TIP-05 - Beacon Frame Advertisement
 `draft` `optional`
 
 ---

--- a/protocol/05.md
+++ b/protocol/05.md
@@ -1,0 +1,6 @@
+# TIP-04 - Beacon Frame Advertisement
+`draft` `optional`
+
+---
+- TODO: put stuff in beaconframe
+

--- a/protocol/05.md
+++ b/protocol/05.md
@@ -1,4 +1,4 @@
-# TIP-04 - Encrypted Events
+# TIP-05 - Encrypted Events
 `draft` `optional`
 
 ---

--- a/protocol/05.md
+++ b/protocol/05.md
@@ -1,6 +1,0 @@
-# TIP-05 - Beacon Frame Advertisement
-`draft` `optional`
-
----
-- TODO: put stuff in beaconframe
-

--- a/protocol/05.md
+++ b/protocol/05.md
@@ -1,0 +1,6 @@
+# TIP-04 - Encrypted Events
+`draft` `optional`
+
+---
+
+- RESERVED: Encrypt Nostr events for privacy / security

--- a/protocol/06.md
+++ b/protocol/06.md
@@ -1,0 +1,6 @@
+# TIP-05 - Beacon Frame Advertisement
+`draft` `optional`
+
+---
+- RESERVED: advertise tollgate in WIFI beaconframe
+

--- a/protocol/06.md
+++ b/protocol/06.md
@@ -1,4 +1,4 @@
-# TIP-05 - Beacon Frame Advertisement
+# TIP-06 - Beacon Frame Advertisement
 `draft` `optional`
 
 ---

--- a/protocol/06.md
+++ b/protocol/06.md
@@ -1,0 +1,7 @@
+# TIP-06 - Nostr Relay
+`draft` `optional`
+
+---
+
+- RESERVED: Nostr relay 
+    - MUST be exposed on port `:4242`

--- a/protocol/10.md
+++ b/protocol/10.md
@@ -1,4 +1,4 @@
-# TIP-06 - Beacon Frame Advertisement
+# TIP-10 - Beacon Frame Advertisement
 `draft` `optional`
 
 ---

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -18,6 +18,7 @@ They exist to document what may be implemented by TollGate compatible devices.
 - [TIP-03: Http server](03.md)
 - [TIP-04: Restrictive OS compatibility](04.md)
 - [TIP-05: Encrypted events](05.md)
+- [TIP-06: Nostr relay](06.md)
 - [TIP-10: Beacon Frame Advertisement](10.md)
 
 ## Breaking changes

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -13,10 +13,11 @@ They exist to document what may be implemented by TollGate compatible devices.
 
 ## List
 
-- [TIP-01: Basic protocol message formats](01.md)
-- [TIP-02: TCP/IP](02.md)
-- [TIP-03: Restrictive OS compatibility](03.md)
-- [TIP-04: Beacon Frame Advertisement](04.md)
+- [TIP-01: Base Events](01.md)
+- [TIP-02: Cashu payments](02.md)
+- [TIP-03: Http server](03.md)
+- [TIP-04: Restrictive OS compatibility](04.md)
+- [TIP-10: Beacon Frame Advertisement](10.md)
 
 ## License
 

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -24,6 +24,7 @@ They exist to document what may be implemented by TollGate compatible devices.
 | When | What |
 |------|------|
 | June 2025 | Cashu payments mint now is added to `<price_per_step>` tag, removing `<mint>` tag |
+| June 2025 | Changed Discovery to no longer be ephemeral |
 
 ## License
 

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -17,6 +17,7 @@ They exist to document what may be implemented by TollGate compatible devices.
 - [TIP-02: Cashu payments](02.md)
 - [TIP-03: Http server](03.md)
 - [TIP-04: Restrictive OS compatibility](04.md)
+- [TIP-04: Encrypted events](04.md)
 - [TIP-10: Beacon Frame Advertisement](10.md)
 
 ## Breaking changes

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -17,7 +17,7 @@ They exist to document what may be implemented by TollGate compatible devices.
 - [TIP-02: Cashu payments](02.md)
 - [TIP-03: Http server](03.md)
 - [TIP-04: Restrictive OS compatibility](04.md)
-- [TIP-04: Encrypted events](05.md)
+- [TIP-05: Encrypted events](05.md)
 - [TIP-10: Beacon Frame Advertisement](10.md)
 
 ## Breaking changes

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -19,6 +19,11 @@ They exist to document what may be implemented by TollGate compatible devices.
 - [TIP-04: Restrictive OS compatibility](04.md)
 - [TIP-10: Beacon Frame Advertisement](10.md)
 
+## Breaking changes
+| When | What |
+|------|------|
+| June 2025 | Cashu payments mint now is added to `<price_per_step>` tag, removing `<mint>` tag |
+
 ## License
 
 All TIPs are public domain.

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -17,7 +17,7 @@ They exist to document what may be implemented by TollGate compatible devices.
 - [TIP-02: Cashu payments](02.md)
 - [TIP-03: Http server](03.md)
 - [TIP-04: Restrictive OS compatibility](04.md)
-- [TIP-04: Encrypted events](04.md)
+- [TIP-04: Encrypted events](05.md)
 - [TIP-10: Beacon Frame Advertisement](10.md)
 
 ## Breaking changes


### PR DESCRIPTION
- ❗️BREAKING CHANGE ❗️Discovery (advertisement) event kind changed
- ❗️BREAKING CHANGE ❗️Moved mint tag into `price_per_step`
- Simplified examples
- Allow any bearer asset instead of just cashu
- Split off cashu into TIP-02
    - Add `mint_fee` so customer can predict price
- Reordered som TIP's

Thinking maybe `price_per_step` should have a unique name so you can distinguish a cashu price from other bearer assets. now you can only guess based on the presence of a `mint_url` at the end.

`price_per_step_cashu` maybe?